### PR TITLE
Chore: Bevy v0.10 to v0.11 cherry picked changes

### DIFF
--- a/bevy_proto_backend/src/impls/bevy_impls/core_pipeline.rs
+++ b/bevy_proto_backend/src/impls/bevy_impls/core_pipeline.rs
@@ -1,7 +1,7 @@
 use bevy::app::App;
 use bevy::core_pipeline::bloom::{BloomCompositeMode, BloomPrefilterSettings, BloomSettings};
 use bevy::core_pipeline::clear_color::ClearColorConfig;
-use bevy::core_pipeline::core_3d::Camera3dDepthLoadOp;
+use bevy::core_pipeline::core_3d::{Camera3dDepthLoadOp, Camera3dDepthTextureUsage};
 use bevy::core_pipeline::fxaa::Fxaa;
 use bevy::core_pipeline::prepass::{DepthPrepass, NormalPrepass};
 use bevy::core_pipeline::tonemapping::{DebandDither, Tonemapping};
@@ -115,11 +115,13 @@ impl_external_schematic! {
     pub struct Camera3dInput {
         pub clear_color: ClearColorConfigInput,
         pub depth_load_op: Camera3dDepthLoadOpInput,
+        pub depth_texture_usages: Camera3dDepthTextureUsage,
     }
     from_to_default!(
         Camera3d,
         Camera3dInput,
         |value: Input| Self {
+            depth_texture_usages: value.depth_texture_usages.into(),
             clear_color: value.clear_color.into(),
             depth_load_op: value.depth_load_op.into()
         }

--- a/bevy_proto_backend/src/impls/bevy_impls/text.rs
+++ b/bevy_proto_backend/src/impls/bevy_impls/text.rs
@@ -28,7 +28,7 @@ impl_external_schematic! {
     pub struct TextInput {
         pub sections: Vec<TextSectionInput>,
         pub alignment: TextAlignmentInput,
-        pub linebreak_behaviour: BreakLineOnInput,
+        pub linebreak_behavior: BreakLineOnInput,
     }
     from_to_input! {
         Text,
@@ -42,7 +42,7 @@ impl_external_schematic! {
             Self {
                 sections,
                 alignment: input.alignment.into(),
-                linebreak_behaviour: input.linebreak_behaviour.into(),
+                linebreak_behavior: input.linebreak_behavior.into(),
             }
         }
     }
@@ -52,7 +52,7 @@ impl_external_schematic! {
             Self {
                 sections: Vec::new(),
                 alignment: base.alignment.into(),
-                linebreak_behaviour: base.linebreak_behaviour.into(),
+                linebreak_behavior: base.linebreak_behavior.into(),
             }
         }
     }

--- a/bevy_proto_backend/src/impls/bevy_impls/ui.rs
+++ b/bevy_proto_backend/src/impls/bevy_impls/ui.rs
@@ -3,9 +3,9 @@ use bevy::math::{Rect, Vec2};
 use bevy::prelude::{BackgroundColor, Button, Label};
 use bevy::reflect::{std_traits::ReflectDefault, Reflect};
 use bevy::ui::{
-    AlignContent, AlignItems, AlignSelf, CalculatedClip, ContentSize, Direction, Display,
-    FlexDirection, FlexWrap, FocusPolicy, GridAutoFlow, GridPlacement, GridTrack, Interaction,
-    JustifyContent, JustifyItems, JustifySelf, Node, Overflow, PositionType,
+    AlignContent, AlignItems, AlignSelf, BorderColor, CalculatedClip, ContentSize, Direction,
+    Display, FlexDirection, FlexWrap, FocusPolicy, GridAutoFlow, GridPlacement, GridTrack,
+    Interaction, JustifyContent, JustifyItems, JustifySelf, Node, Overflow, PositionType,
     RelativeCursorPosition, RepeatedGridTrack, Style, UiImage, UiRect, Val, ZIndex,
 };
 
@@ -54,6 +54,20 @@ impl_external_schematic! {
     from_to_default! {
         BackgroundColor,
         BackgroundColorInput,
+        |value: Input| Self(value.0.into())
+    }
+}
+
+impl_external_schematic! {
+    #[schematic(from = BorderColorInput)]
+    struct BorderColor();
+    // ---
+    #[derive(Reflect)]
+    #[reflect(Default)]
+    pub struct BorderColorInput(pub ProtoColor);
+    from_to_default! {
+        BorderColor,
+        BorderColorInput,
         |value: Input| Self(value.0.into())
     }
 }

--- a/bevy_proto_backend/src/impls/bevy_impls/ui.rs
+++ b/bevy_proto_backend/src/impls/bevy_impls/ui.rs
@@ -3,9 +3,10 @@ use bevy::math::{Rect, Vec2};
 use bevy::prelude::{BackgroundColor, Button, Label};
 use bevy::reflect::{std_traits::ReflectDefault, Reflect};
 use bevy::ui::{
-    AlignContent, AlignItems, AlignSelf, CalculatedClip, Direction, Display,
-    FlexDirection, FlexWrap, FocusPolicy, Interaction, JustifyContent, Node, Overflow,
-    PositionType, RelativeCursorPosition, Style, UiImage, UiRect, Val, ZIndex,
+    AlignContent, AlignItems, AlignSelf, CalculatedClip, ContentSize, Direction, Display,
+    FlexDirection, FlexWrap, FocusPolicy, GridAutoFlow, GridPlacement, GridTrack, Interaction,
+    JustifyContent, JustifyItems, JustifySelf, Node, Overflow, PositionType,
+    RelativeCursorPosition, RepeatedGridTrack, Style, UiImage, UiRect, Val, ZIndex,
 };
 
 use crate::impls::macros::{from_to, from_to_default, register_schematic};
@@ -18,6 +19,7 @@ pub(super) fn register(app: &mut App) {
         BackgroundColor,
         Button,
         CalculatedClip,
+        ContentSize,
         FocusPolicy,
         Interaction,
         Label,
@@ -38,8 +40,6 @@ pub(super) fn register(app: &mut App) {
         .register_type::<JustifyContentInput>()
         .register_type::<OverflowInput>()
         .register_type::<PositionTypeInput>()
-        .register_type::<SizeInput>()
-        .register_type::<SizeInput>()
         .register_type::<UiRectInput>()
         .register_type::<ValInput>();
 }
@@ -85,6 +85,26 @@ impl_external_schematic! {
         CalculatedClipInput,
         |value: Input| Self {
             clip: value.clip,
+        }
+    }
+}
+
+impl_external_schematic! {
+    #[schematic(from = ContentSizeInput)]
+    struct ContentSize {}
+    // ---
+    #[derive(Reflect)]
+    #[reflect(Default)]
+    pub struct ContentSizeInput {
+        pub size: Vec2,
+        pub preserve_aspect_ratio: bool,
+    }
+    from_to_default! {
+        ContentSize,
+        ContentSizeInput,
+        |value: Input| Self {
+            size: value.size,
+            preserve_aspect_ratio: value.preserve_aspect_ratio,
         }
     }
 }
@@ -189,6 +209,7 @@ impl_external_schematic! {
     pub struct StyleInput {
         pub display: DisplayInput,
         pub position_type: PositionTypeInput,
+        pub overflow: OverflowInput,
         pub direction: DirectionInput,
         pub flex_direction: FlexDirectionInput,
         pub flex_wrap: FlexWrapInput,
@@ -196,19 +217,34 @@ impl_external_schematic! {
         pub align_self: AlignSelfInput,
         pub align_content: AlignContentInput,
         pub justify_content: JustifyContentInput,
-        pub position: UiRectInput,
+        pub justify_self: JustifySelf,
+        pub justify_items: JustifyItems,
         pub margin: UiRectInput,
         pub padding: UiRectInput,
         pub border: UiRectInput,
         pub flex_grow: f32,
         pub flex_shrink: f32,
         pub flex_basis: ValInput,
-        pub size: SizeInput,
-        pub min_size: SizeInput,
-        pub max_size: SizeInput,
         pub aspect_ratio: Option<f32>,
-        pub overflow: OverflowInput,
-        pub gap: SizeInput,
+        pub left: Val,
+        pub right: Val,
+        pub top: Val,
+        pub bottom: Val,
+        pub width: Val,
+        pub min_width: Val,
+        pub max_width: Val,
+        pub height: Val,
+        pub min_height: Val,
+        pub max_height: Val,
+        pub row_gap: Val,
+        pub column_gap: Val,
+        pub grid_auto_flow: GridAutoFlow,
+        pub grid_template_rows: Vec<RepeatedGridTrack>,
+        pub grid_template_columns: Vec<RepeatedGridTrack>,
+        pub grid_auto_rows: Vec<GridTrack>,
+        pub grid_auto_columns: Vec<GridTrack>,
+        pub grid_row: GridPlacement,
+        pub grid_column: GridPlacement,
     }
     from_to_default! {
         Style,
@@ -216,6 +252,7 @@ impl_external_schematic! {
         |value: Input| Self {
             display: value.display.into(),
             position_type: value.position_type.into(),
+            overflow: value.overflow.into(),
             direction: value.direction.into(),
             flex_direction: value.flex_direction.into(),
             flex_wrap: value.flex_wrap.into(),
@@ -223,19 +260,34 @@ impl_external_schematic! {
             align_self: value.align_self.into(),
             align_content: value.align_content.into(),
             justify_content: value.justify_content.into(),
-            position: value.position.into(),
+            justify_self: value.justify_self.into(),
+            justify_items: value.justify_items.into(),
             margin: value.margin.into(),
             padding: value.padding.into(),
             border: value.border.into(),
             flex_grow: value.flex_grow,
             flex_shrink: value.flex_shrink,
             flex_basis: value.flex_basis.into(),
-            size: value.size.into(),
-            min_size: value.min_size.into(),
-            max_size: value.max_size.into(),
             aspect_ratio: value.aspect_ratio,
-            overflow: value.overflow.into(),
-            gap: value.gap.into(),
+            left: value.left.into(),
+            right: value.right.into(),
+            top: value.top.into(),
+            bottom: value.bottom.into(),
+            width: value.width.into(),
+            min_width: value.min_width.into(),
+            max_width: value.max_width.into(),
+            height: value.height.into(),
+            min_height: value.min_height.into(),
+            max_height: value.max_height.into(),
+            row_gap: value.row_gap.into(),
+            column_gap: value.column_gap.into(),
+            grid_auto_flow: value.grid_auto_flow.into(),
+            grid_template_rows: value.grid_template_rows.into(),
+            grid_template_columns: value.grid_template_columns.into(),
+            grid_auto_rows: value.grid_auto_rows.into(),
+            grid_auto_columns: value.grid_auto_columns.into(),
+            grid_row: value.grid_row.into(),
+            grid_column: value.grid_column.into(),
         }
     }
 
@@ -445,20 +497,6 @@ impl_external_schematic! {
         }
     }
 
-    #[derive(Reflect)]
-    #[reflect(Default)]
-    pub struct SizeInput {
-        pub width: ValInput,
-        pub height: ValInput,
-    }
-    from_to_default! {
-        Size,
-        SizeInput,
-        |value: Input| Self {
-            width: value.width.into(),
-            height: value.height.into(),
-        }
-    }
 
     #[derive(Reflect)]
     #[reflect(Default)]

--- a/bevy_proto_backend/src/impls/bevy_impls/ui.rs
+++ b/bevy_proto_backend/src/impls/bevy_impls/ui.rs
@@ -136,7 +136,7 @@ impl_external_schematic! {
     #[derive(Reflect)]
     #[reflect(Default)]
     pub enum InteractionInput {
-        Clicked,
+        Pressed,
         Hovered,
         None,
     }
@@ -144,7 +144,7 @@ impl_external_schematic! {
         Interaction,
         InteractionInput,
         |value: Input| match value {
-            Input::Clicked => Self::Clicked,
+            Input::Pressed => Self::Pressed,
             Input::Hovered => Self::Hovered,
             Input::None => Self::None,
         }

--- a/bevy_proto_backend/src/proto/commands.rs
+++ b/bevy_proto_backend/src/proto/commands.rs
@@ -186,7 +186,7 @@ impl<T: Prototypical, C: Config<T>> ProtoInsertCommand<T, C> {
 }
 
 impl<T: Prototypical, C: Config<T>> Command for ProtoInsertCommand<T, C> {
-    fn write(self, world: &mut World) {
+    fn apply(self, world: &mut World) {
         self.data.assert_is_registered(world);
 
         self.data
@@ -217,7 +217,7 @@ impl<T: Prototypical, C: Config<T>> ProtoRemoveCommand<T, C> {
 }
 
 impl<T: Prototypical, C: Config<T>> Command for ProtoRemoveCommand<T, C> {
-    fn write(self, world: &mut World) {
+    fn apply(self, world: &mut World) {
         self.data.assert_is_registered(world);
 
         self.data

--- a/bevy_proto_backend/src/proto/event.rs
+++ b/bevy_proto_backend/src/proto/event.rs
@@ -1,5 +1,6 @@
 use crate::proto::Prototypical;
 use bevy::asset::Handle;
+use bevy::prelude::Event;
 
 /// Asset lifecycle events for [prototype] assets.
 ///
@@ -9,7 +10,7 @@ use bevy::asset::Handle;
 ///
 /// [prototype]: Prototypical
 /// [`AssetEvent`]: bevy::asset::AssetEvent
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Event)]
 pub enum ProtoAssetEvent<T: Prototypical> {
     /// This event is fired when a prototype has been successfully created,
     /// registered, and cached.

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -531,7 +531,7 @@ pub struct ButtonBundle {
     #[reflect(default)]
     pub background_color: bevy_impls::ui::BackgroundColorInput,
     #[reflect(default)]
-    pub background_color: bevy_impls::ui::BorderColorInput,
+    pub border_color: bevy_impls::ui::BorderColorInput,
     #[reflect(default)]
     pub image: bevy_impls::ui::UiImageInput,
     #[reflect(default)]

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -531,6 +531,8 @@ pub struct ButtonBundle {
     #[reflect(default)]
     pub background_color: bevy_impls::ui::BackgroundColorInput,
     #[reflect(default)]
+    pub background_color: bevy_impls::ui::BorderColorInput,
+    #[reflect(default)]
     pub image: bevy_impls::ui::UiImageInput,
     #[reflect(default)]
     pub transform: Transform,
@@ -554,6 +556,7 @@ impl FromSchematicInput<ButtonBundle> for bevy::ui::node_bundles::ButtonBundle {
             interaction: input.interaction.into(),
             focus_policy: input.focus_policy.into(),
             background_color: input.background_color.into(),
+            border_color: input.border_color.into(),
             image: bevy::ui::UiImage::from_input(input.image, context),
             transform: input.transform,
             global_transform: input.global_transform,


### PR DESCRIPTION
Created a PR to move over the cherry picked changes for v0.11 migration. The comments followed the section title in the migration guide whenever possible as per link here https://bevyengine.org/learn/migration-guides/0.10-0.11/